### PR TITLE
[Fix] Use a new version of mmcv in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ MIM provides a unified API for launching and installing OpenMMLab projects and t
     ```bash
     # install latest version of mmcv-full
     > mim install mmcv-full  # wheel
-    # install 1.2.7
-    > mim install mmcv-full==1.2.7
+    # install 1.3.1
+    > mim install mmcv-full==1.3.1
     # install master branch
     > mim install mmcv-full -f https://github.com/open-mmlab/mmcv.git
 
@@ -105,7 +105,7 @@ MIM provides a unified API for launching and installing OpenMMLab projects and t
     # install mmcls
     # install mmcls will automatically install mmcv if it is not installed
     install('mmcv-full', find_url='https://github.com/open-mmlab/mmcv.git')
-    install('mmcv-full==1.2.7', find_url='https://github.com/open-mmlab/mmcv.git')
+    install('mmcv-full==1.3.1', find_url='https://github.com/open-mmlab/mmcv.git')
 
     # install extension based on OpenMMLab
     install('mmcls-project', find_url='https://github.com/xxx/mmcls-project.git')

--- a/mim/commands/install.py
+++ b/mim/commands/install.py
@@ -73,8 +73,8 @@ def cli(
     \b
     # install latest version of mmcv-full
     > mim install mmcv-full  # wheel
-    # install 1.2.7
-    > mim install mmcv-full==1.2.7
+    # install 1.3.1
+    > mim install mmcv-full==1.3.1
     # install master branch
     > mim install mmcv-full -f https://github.com/open-mmlab/mmcv.git
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -27,8 +27,8 @@ def test_mmcv_install():
     result = runner.invoke(install, ['mmcv-full', '--yes'])
     assert result.exit_code == 0
 
-    # mim install mmcv-full==1.2.7 --yes
-    result = runner.invoke(install, ['mmcv-full==1.2.7', '--yes'])
+    # mim install mmcv-full==1.3.1 --yes
+    result = runner.invoke(install, ['mmcv-full==1.3.1', '--yes'])
     assert result.exit_code == 0
 
     # mim uninstall mmcv-full --yes


### PR DESCRIPTION
The demo is recorded under env with torch 1.8.0 and CUDA 11.1. MMCV 1.2.7 has no pre-built wheel which meets this requirement.