### PR TITLE
[Improvement] Shorten mim commands

### DIFF
--- a/mim/commands/run.py
+++ b/mim/commands/run.py
@@ -14,6 +14,7 @@ from mim.utils import (
     get_installed_path,
     highlighted_error,
     is_installed,
+    module_full_name,
     recursively_find,
 )
 
@@ -77,6 +78,11 @@ def run(
         other_args (tuple, optional): Other arguments, will be passed to the
             codebase's script. Defaults to ().
     """
+    full_name = module_full_name(package)
+    if full_name == '':
+        msg = f"Can't determine a unique package given abbreviation {package}"
+        raise ValueError(highlighted_error(msg))
+    package = full_name
 
     if not is_installed(package):
         msg = (f'The codebase {package} is not installed, '

--- a/mim/commands/test.py
+++ b/mim/commands/test.py
@@ -13,6 +13,7 @@ from mim.utils import (
     get_installed_path,
     highlighted_error,
     is_installed,
+    module_full_name,
     recursively_find,
 )
 
@@ -23,7 +24,8 @@ from mim.utils import (
     cls=CustomCommand)
 @click.argument('package', type=str, callback=param2lowercase)
 @click.argument('config', type=str)
-@click.option('--checkpoint', type=str, default=None, help='checkpoint path')
+@click.option(
+    '-C', '--checkpoint', type=str, default=None, help='checkpoint path')
 @click.option(
     '--launcher',
     type=click.Choice(['none', 'pytorch', 'slurm'], case_sensitive=False),
@@ -37,20 +39,24 @@ from mim.utils import (
           'slurm / pytorch launchers). If set to None, will randomly choose '
           'a port between 20000 and 30000'))
 @click.option(
+    '-G',
     '--gpus',
     type=int,
     help='Number of gpus to use (only applicable to launcher == "slurm")')
 @click.option(
+    '-g',
     '--gpus-per-node',
     type=int,
     help=('Number of gpus per node to use '
           '(only applicable to launcher == "slurm")'))
 @click.option(
+    '-c',
     '--cpus-per-task',
     type=int,
     default=2,
     help='Number of cpus per task (only applicable to launcher == "slurm")')
 @click.option(
+    '-p',
     '--partition',
     type=str,
     help='The partition to use (only applicable to launcher == "slurm")')
@@ -151,6 +157,11 @@ def test(
         other_args (tuple, optional): Other arguments, will be passed to the
             codebase's training script. Defaults to ().
     """
+    full_name = module_full_name(package)
+    if full_name == '':
+        msg = f"Can't determine a unique package given abbreviation {package}"
+        raise ValueError(highlighted_error(msg))
+    package = full_name
 
     # `checkpoint` is a compulsory argument for all mm codebases except
     # mmtracking, so that if the codebase is not mmtracking, user must specify

--- a/mim/commands/train.py
+++ b/mim/commands/train.py
@@ -13,6 +13,7 @@ from mim.utils import (
     get_installed_path,
     highlighted_error,
     is_installed,
+    module_full_name,
     recursively_find,
 )
 
@@ -35,18 +36,22 @@ from mim.utils import (
     help=('The port used for inter-process communication (only applicable to '
           'slurm / pytorch launchers). If set to None, will randomly choose '
           'a port between 20000 and 30000. '))
-@click.option('--gpus', type=int, default=1, help='Number of gpus to use')
 @click.option(
+    '-G', '--gpus', type=int, default=1, help='Number of gpus to use')
+@click.option(
+    '-g',
     '--gpus-per-node',
     type=int,
     help=('Number of gpus per node to use '
           '(only applicable to launcher == "slurm")'))
 @click.option(
+    '-c',
     '--cpus-per-task',
     type=int,
     default=2,
     help='Number of cpus per task (only applicable to launcher == "slurm")')
 @click.option(
+    '-p',
     '--partition',
     type=str,
     help='The partition to use (only applicable to launcher == "slurm")')
@@ -139,6 +144,12 @@ def train(
         other_args (tuple, optional): Other arguments, will be passed to the
             codebase's training script. Defaults to ().
     """
+    full_name = module_full_name(package)
+    if full_name == '':
+        msg = f"Can't determine a unique package given abbreviation {package}"
+        raise ValueError(highlighted_error(msg))
+    package = full_name
+
     # If launcher == "slurm", must have following args
     if launcher == 'slurm':
         msg = ('If launcher is slurm, '

--- a/mim/utils/__init__.py
+++ b/mim/utils/__init__.py
@@ -32,6 +32,7 @@ from .utils import (
     highlighted_error,
     is_installed,
     is_version_equal,
+    module_full_name,
     parse_url,
     read_installation_records,
     recursively_find,
@@ -81,5 +82,6 @@ __all__ = [
     'highlighted_error',
     'extract_tar',
     'get_release_version',
+    'module_full_name',
     'MODULE2PKG',
 ]

--- a/mim/utils/utils.py
+++ b/mim/utils/utils.py
@@ -506,3 +506,25 @@ def extract_tar(tar_path: str, dst: str) -> None:
 
     with tarfile.open(tar_path, 'r') as tar_file:
         tar_file.extractall(dst)
+
+
+def module_full_name(abbr: str) -> str:
+    """Get the full name of the module given abbreviation.
+
+    Args:
+        abbr (str): The abbreviation, should be the sub-string of one
+            (and only one) supported module.
+
+    Return:
+        str: The full name of the corresponding module. If abbr is the
+            sub-string of zero / multiple module names, return empty string.
+    """
+    supported_pkgs = [
+        PKG2MODULE[k] if k in PKG2MODULE else k for k in PKG2PROJECT
+    ]
+    supported_pkgs = list(set(supported_pkgs))
+    names = [x for x in supported_pkgs if abbr in x]
+    if len(names) == 1:
+        return names[0]
+    else:
+        return ''


### PR DESCRIPTION
1. Add abbreviations to mim sub-commands: train, test, gridsearch
2. Sub-commands train, test, run, gridsearch can accept abbreviations of package names as long as the abbrev is a substring of one (and only one) package name.