### PR TITLE
[Fix] Fix install ambiguous

### DIFF
--- a/mim/commands/install.py
+++ b/mim/commands/install.py
@@ -252,7 +252,11 @@ def looks_like_path(name: str) -> bool:
 
 
 def is_installable_dir(name: str) -> bool:
-    """Is path is a directory containing setup.py."""
+    """Check whether path is a directory containing setup.py.
+
+    Args:
+        name (str): The string to be checked.
+    """
     path = osp.abspath(name)
     if osp.isdir(path):
         setup_py = osp.join(path, 'setup.py')

--- a/mim/commands/install.py
+++ b/mim/commands/install.py
@@ -115,7 +115,11 @@ def install(package: str,
     target_pkg, target_version = split_package_version(package)
 
     # whether install from local repo
-    is_install_local_repo = osp.isdir(osp.abspath(target_pkg)) and not find_url
+    if ((package.startswith('.') or package.startswith('/'))
+            and osp.isdir(osp.abspath(target_pkg)) and not find_url):
+        is_install_local_repo = True
+    else:
+        is_install_local_repo = False
 
     # whether install master branch from github
     is_install_master = bool(not target_version and find_url)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -64,10 +64,6 @@ def test_mmrepo_install():
         result = runner.invoke(install, ['./mmclassification', '--yes'])
         assert result.exit_code == 0
 
-        # mim install mmclassification
-        result = runner.invoke(install, ['mmclassification', '--yes'])
-        assert result.exit_code == 0
-
         os.chdir(current_root)
 
     # mim install mmcls --yes


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation
```shell
>>> git clone https://github.com/open-mmlab/mmclassification.git
>>> cd mmclassification
```
If we type "mim install mmcls" in the current directory (mmclassification), it will raise an exception before the PR because it wrongly confirms `os.abspath('mmcls')` is a valid path. However, our intention is to install mmcls from a remote source.

## BC-breaking (Optional)
Does the modification introduce changes that break the back-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)
If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
