### PR TITLE
add `model_info_local` argument to `download` function

### DIFF
--- a/mim/commands/download.py
+++ b/mim/commands/download.py
@@ -46,7 +46,8 @@ def cli(package: str,
 
 def download(package: str,
              configs: List[str],
-             dest_root: Optional[str] = None) -> List[str]:
+             dest_root: Optional[str] = None,
+             model_info_local: bool = True) -> List[str]:
     """Download checkpoints from url and parse configs from package.
 
     Args:
@@ -54,6 +55,8 @@ def download(package: str,
         configs (List[str]): List of config ids.
         dest_root (Optional[str]): Destination directory to save checkpoint and
             config. Default: None.
+        model_info_local (bool): Query model info from local environment or
+            remote guthub. Default: True.
     """
     if dest_root is None:
         dest_root = DEFAULT_CACHE_DIR
@@ -73,7 +76,7 @@ def download(package: str,
 
     checkpoints = []
     model_info = get_model_info(
-        package, shown_fields=['weight', 'config'], to_dict=True)
+        package, shown_fields=['weight', 'config'], to_dict=True, local=model_info_local)
     valid_configs = model_info.keys()
     invalid_configs = set(configs) - set(valid_configs)
     if invalid_configs:

--- a/mim/commands/download.py
+++ b/mim/commands/download.py
@@ -76,7 +76,10 @@ def download(package: str,
 
     checkpoints = []
     model_info = get_model_info(
-        package, shown_fields=['weight', 'config'], to_dict=True, local=model_info_local)
+        package,
+        shown_fields=['weight', 'config'],
+        to_dict=True,
+        local=model_info_local)
     valid_configs = model_info.keys()
     invalid_configs = set(configs) - set(valid_configs)
     if invalid_configs:

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -44,8 +44,12 @@ def test_download():
     checkpoints = download('mmcls', ['resnet18_b16x8_cifar10'])
     assert checkpoints == ['resnet18_b16x8_cifar10_20200823-f906fa4e.pth']
     checkpoints = download('mmcls', ['resnet18_b16x8_cifar10'])
+    checkpoints = download('mmcls', ['resnet18_b16x8_cifar10'], model_info_local=False)
+    assert checkpoints == ['resnet18_b16x8_cifar10_20200823-f906fa4e.pth']
 
     # mim download mmcls --config resnet18_b16x8_cifar10 --dest temp_root
     with tempfile.TemporaryDirectory() as temp_root:
         checkpoints = download('mmcls', ['resnet18_b16x8_cifar10'], temp_root)
+        assert checkpoints == ['resnet18_b16x8_cifar10_20200823-f906fa4e.pth']
+        checkpoints = download('mmcls', ['resnet18_b16x8_cifar10'], temp_root, model_info_local=False)
         assert checkpoints == ['resnet18_b16x8_cifar10_20200823-f906fa4e.pth']

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -44,12 +44,17 @@ def test_download():
     checkpoints = download('mmcls', ['resnet18_b16x8_cifar10'])
     assert checkpoints == ['resnet18_b16x8_cifar10_20200823-f906fa4e.pth']
     checkpoints = download('mmcls', ['resnet18_b16x8_cifar10'])
-    checkpoints = download('mmcls', ['resnet18_b16x8_cifar10'], model_info_local=False)
+    checkpoints = download('mmcls',
+                           ['resnet18_b16x8_cifar10'],
+                           model_info_local=False)
     assert checkpoints == ['resnet18_b16x8_cifar10_20200823-f906fa4e.pth']
 
     # mim download mmcls --config resnet18_b16x8_cifar10 --dest temp_root
     with tempfile.TemporaryDirectory() as temp_root:
         checkpoints = download('mmcls', ['resnet18_b16x8_cifar10'], temp_root)
         assert checkpoints == ['resnet18_b16x8_cifar10_20200823-f906fa4e.pth']
-        checkpoints = download('mmcls', ['resnet18_b16x8_cifar10'], temp_root, model_info_local=False)
+        checkpoints = download('mmcls',
+                               ['resnet18_b16x8_cifar10'],
+                               temp_root,
+                               model_info_local=False)
         assert checkpoints == ['resnet18_b16x8_cifar10_20200823-f906fa4e.pth']


### PR DESCRIPTION
## Motivation
We want to parse model info from remote when using download function. Fixes https://github.com/open-mmlab/mim/issues/51

## Modification
add `model_info_local` argument to `download` function.

## BC-breaking (Optional)
Previous usage is not affected.
