### PR TITLE
[Fix] Fix config search when train, test and gridsearch

### DIFF
--- a/mim/commands/gridsearch.py
+++ b/mim/commands/gridsearch.py
@@ -222,7 +222,16 @@ def gridsearch(
     pkg_root = get_installed_path(package)
 
     if not osp.exists(config):
-        files = recursively_find(pkg_root, osp.basename(config))
+        # configs is put in pkg/.mim in PR #68
+        config_root = osp.join(pkg_root, '.mim', 'configs')
+        if not osp.exists(config_root):
+            # If not pkg/.mim/config, try to search the whole pkg root.
+            config_root = pkg_root
+
+        # pkg/.mim/configs is a symbolic link to the real config folder,
+        # so we need to follow links.
+        files = recursively_find(
+            pkg_root, osp.basename(config), followlinks=True)
 
         if len(files) == 0:
             msg = (f"The path {config} doesn't exist and we can not "

--- a/mim/commands/test.py
+++ b/mim/commands/test.py
@@ -211,7 +211,16 @@ def test(
     pkg_root = get_installed_path(package)
 
     if not osp.exists(config):
-        files = recursively_find(pkg_root, osp.basename(config))
+        # configs is put in pkg/.mim in PR #68
+        config_root = osp.join(pkg_root, '.mim', 'configs')
+        if not osp.exists(config_root):
+            # If not pkg/.mim/config, try to search the whole pkg root.
+            config_root = pkg_root
+
+        # pkg/.mim/configs is a symbolic link to the real config folder,
+        # so we need to follow links.
+        files = recursively_find(
+            pkg_root, osp.basename(config), followlinks=True)
 
         if len(files) == 0:
             msg = (f"The path {config} doesn't exist and we can not find "

--- a/mim/commands/train.py
+++ b/mim/commands/train.py
@@ -188,7 +188,16 @@ def train(
     pkg_root = get_installed_path(package)
 
     if not osp.exists(config):
-        files = recursively_find(pkg_root, osp.basename(config))
+        # configs is put in pkg/.mim in PR #68
+        config_root = osp.join(pkg_root, '.mim', 'configs')
+        if not osp.exists(config_root):
+            # If not pkg/.mim/config, try to search the whole pkg root.
+            config_root = pkg_root
+
+        # pkg/.mim/configs is a symbolic link to the real config folder,
+        # so we need to follow links.
+        files = recursively_find(
+            pkg_root, osp.basename(config), followlinks=True)
 
         if len(files) == 0:
             msg = (f"The path {config} doesn't exist and we can not find "

--- a/mim/utils/utils.py
+++ b/mim/utils/utils.py
@@ -369,18 +369,19 @@ def cast2lowercase(input: Union[list, tuple, str]) -> Any:
         return outputs
 
 
-def recursively_find(root: str, base_name: str) -> list:
+def recursively_find(root: str, base_name: str, followlinks=False) -> list:
     """Recursive list a directory, return all files with a given base_name.
 
     Args:
         root (str): The root directory to list.
         base_name (str): The base_name.
+        followlinks (bool): Follow symbolic links. Defaults to False.
 
     Return:
         Files with given base_name.
     """
     files = []
-    for _root, _, _files in os.walk(root):
+    for _root, _, _files in os.walk(root, followlinks=followlinks):
         if base_name in _files:
             files.append(osp.join(_root, base_name))
 


### PR DESCRIPTION
## Motivation
mim will search config files from the codebase if the config path does not exist.
But by default `os.walk` won't follow links, and `pkg/.mim/configs` is a symbolic link to the real config folder. So this search does not work in fact.

## Modification
Add `followlinks` option in `recursively_find`, and use it when searching config files.
In addition, now mim will search `pkg/.mim/configs` if it exists, instead of search the whole package root directly.
