### PR TITLE
[Fix] Show the real path when use an alternative config file

### DIFF
--- a/mim/commands/gridsearch.py
+++ b/mim/commands/gridsearch.py
@@ -233,10 +233,13 @@ def gridsearch(
                 f"The path {config} doesn't exist and we find multiple "
                 f'config files with same name in codebase {package}: {files}.')
             raise ValueError(highlighted_error(msg))
+
+        # Use realpath instead of the symbolic path in pkg/.mim
+        config_path = osp.realpath(files[0])
         click.echo(
             f"The path {config} doesn't exist but we find the config file "
-            f'in codebase {package}, will use {files[0]} instead.')
-        config = files[0]
+            f'in codebase {package}, will use {config_path} instead.')
+        config = config_path
 
     # tools will be put in package/.mim in PR #68
     train_script = osp.join(pkg_root, '.mim', 'tools', 'train.py')

--- a/mim/commands/test.py
+++ b/mim/commands/test.py
@@ -222,10 +222,13 @@ def test(
                 f"The path {config} doesn't exist and we find multiple "
                 f'config files with same name in codebase {package}: {files}.')
             raise ValueError(highlighted_error(msg))
+
+        # Use realpath instead of the symbolic path in pkg/.mim
+        config_path = osp.realpath(files[0])
         click.echo(
             f"The path {config} doesn't exist but we find the config file "
-            f'in codebase {package}, will use {files[0]} instead.')
-        config = files[0]
+            f'in codebase {package}, will use {config_path} instead.')
+        config = config_path
 
     # We know that 'config' exists and is legal.
     test_script = osp.join(pkg_root, 'tools', 'test.py')

--- a/mim/commands/train.py
+++ b/mim/commands/train.py
@@ -200,10 +200,12 @@ def train(
                 f'config files with same name in codebase {package}: {files}.')
             raise ValueError(highlighted_error(msg))
 
+        # Use realpath instead of the symbolic path in pkg/.mim
+        config_path = osp.realpath(files[0])
         click.echo(
             f"The path {config} doesn't exist but we find the config file "
-            f'in codebase {package}, will use {files[0]} instead.')
-        config = files[0]
+            f'in codebase {package}, will use {config_path} instead.')
+        config = config_path
 
     # tools will be put in package/.mim in PR #68
     train_script = osp.join(pkg_root, '.mim', 'tools', 'train.py')


### PR DESCRIPTION
## Motivation
If mim finds a config file in the codebase, it will show the file path. But now it will show a link path, for example:
```
The path resnet18_b16x8_cifar10.py doesn't exist but we find the config file in codebase mmcls, will use /home/xxx/mmclassification/mmcls/.mim/configs/resnet/resnet18_b16x8_cifar10.py instead.
```

## Modification
Show the real path instead of the symbolic path. like
```
The path resnet18_b16x8_cifar10.py doesn't exist but we find the config file in codebase mmcls, will use /home/xxx/mmclassification/configs/resnet/resnet18_b16x8_cifar10.py instead.
```