### PR TITLE
[Fix] TypeError of gridsearch command

### DIFF
--- a/mim/commands/gridsearch.py
+++ b/mim/commands/gridsearch.py
@@ -278,7 +278,7 @@ def gridsearch(
     for arg in search_args_dict:
         try:
             arg_value = get_config(cfg, arg)
-            if arg_value and not isinstance(arg_value, str):
+            if arg_value is not None and not isinstance(arg_value, str):
                 search_args_dict[arg] = [
                     eval(x) for x in search_args_dict[arg]
                 ]


### PR DESCRIPTION
Fix the bug: When the default value of an argument is 0,  the `gridsearch` command gets the wrong type of the corresponding argument to search. 