### PR TITLE
Use sys.executable for calling Python

### DIFF
--- a/mim/commands/install.py
+++ b/mim/commands/install.py
@@ -2,6 +2,7 @@
 import os
 import os.path as osp
 import shutil
+import sys
 import tempfile
 from distutils.version import LooseVersion
 from pkg_resources import parse_requirements, resource_filename
@@ -32,6 +33,8 @@ from mim.utils import (
     parse_url,
     split_package_version,
 )
+
+PYTHON = sys.executable
 
 
 @click.command('install')
@@ -463,7 +466,7 @@ def install_from_repo(repo_root: str,
     third_dependencies = osp.join(repo_root, 'requirements', 'build.txt')
     if osp.exists(third_dependencies):
         dep_cmd = [
-            'python', '-m', 'pip', 'install', '-r', third_dependencies,
+            PYTHON, '-m', 'pip', 'install', '-r', third_dependencies,
             '--default-timeout', f'{timeout}'
         ]
         if is_user_dir:
@@ -471,7 +474,7 @@ def install_from_repo(repo_root: str,
 
         call_command(dep_cmd)
 
-    install_cmd = ['python', '-m', 'pip', 'install']
+    install_cmd = [PYTHON, '-m', 'pip', 'install']
     if is_editable:
         install_cmd.append('-e')
     else:
@@ -561,7 +564,7 @@ def install_from_wheel(package: str,
     click.echo(f'installing {package} from wheel.')
 
     install_cmd = [
-        'python', '-m', 'pip', '--default-timeout', f'{timeout}', 'install'
+        PYTHON, '-m', 'pip', '--default-timeout', f'{timeout}', 'install'
     ]
     if version:
         install_cmd.append(f'{package}=={version}')


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Fix #108 

## Modification

Use `sys.executable` instead of `'python'` when calling Python

## BC-breaking (Optional)

No

## Use cases (Optional)
If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
