### PR TITLE
mim install does not work with pip >= 22.1

### DIFF
--- a/mim/commands/install.py
+++ b/mim/commands/install.py
@@ -477,7 +477,10 @@ def install_from_repo(repo_root: str,
     else:
         # solving issues related to out-of-tree builds
         # more datails at https://github.com/pypa/pip/issues/7555
-        if LooseVersion(pip.__version__) >= LooseVersion('21.1.1'):
+        # starting from pip==21.3 in-tree builds are the default and --use-feature=in-tree-build is ignored
+        # more details at https://pip.pypa.io/en/stable/news/#id82
+        # starting from pip==22.1 --use-feature=in-tree-build raises an error
+        if LooseVersion('21.1.1') <= LooseVersion(pip.__version__) < LooseVersion('22.1'):
             install_cmd.append('--use-feature=in-tree-build')
     install_cmd.append(repo_root)
     if is_user_dir:

--- a/mim/commands/install.py
+++ b/mim/commands/install.py
@@ -477,10 +477,12 @@ def install_from_repo(repo_root: str,
     else:
         # solving issues related to out-of-tree builds
         # more datails at https://github.com/pypa/pip/issues/7555
-        # starting from pip==21.3 in-tree builds are the default and --use-feature=in-tree-build is ignored
+        # starting from pip==21.3 in-tree builds are the default
+        #   and --use-feature=in-tree-build is ignored
         # more details at https://pip.pypa.io/en/stable/news/#id82
         # starting from pip==22.1 --use-feature=in-tree-build raises an error
-        if LooseVersion('21.1.1') <= LooseVersion(pip.__version__) < LooseVersion('22.1'):
+        if LooseVersion('21.1.1') <= LooseVersion(
+                pip.__version__) < LooseVersion('22.1'):
             install_cmd.append('--use-feature=in-tree-build')
     install_cmd.append(repo_root)
     if is_user_dir:


### PR DESCRIPTION
## Motivation
With pip==22.1 command `min install X` produces the following error:
```
#38 7.318 Usage:   
#38 7.318   /opt/conda/bin/python -m pip install [options] <requirement specifier> [package-index-options] ...
#38 7.318   /opt/conda/bin/python -m pip install [options] -r <requirements file> [package-index-options] ...
#38 7.318   /opt/conda/bin/python -m pip install [options] [-e] <vcs project url> ...
#38 7.318   /opt/conda/bin/python -m pip install [options] [-e] <local project path> ...
#38 7.318   /opt/conda/bin/python -m pip install [options] <archive url/path> ...
#38 7.318 
#38 7.318 option --use-feature: invalid choice: 'in-tree-build' (choose from '2020-resolver', 'fast-deps')
#38 7.380 Traceback (most recent call last):
#38 7.380   File "/home/research/.local/lib/python3.8/site-packages/mim/utils/utils.py", line 418, in call_command
#38 7.380     subprocess.check_call(cmd)
#38 7.380   File "/opt/conda/lib/python3.8/subprocess.py", line 364, in check_call
#38 7.380     raise CalledProcessError(retcode, cmd)
#38 7.380 subprocess.CalledProcessError: Command '['python', '-m', 'pip', 'install', '--use-feature=in-tree-build', '/tmp/tmpncrbxmxz/mmaction2']' returned non-zero exit status 2.
#38 7.380 
#38 7.380 During handling of the above exception, another exception occurred:
#38 7.380 
#38 7.380 Traceback (most recent call last):
#38 7.380   File "/home/research/.local/bin/mim", line 8, in <module>
#38 7.380     sys.exit(cli())
#38 7.380   File "/opt/conda/lib/python3.8/site-packages/click/core.py", line 829, in __call__
#38 7.380     return self.main(*args, **kwargs)
#38 7.380   File "/opt/conda/lib/python3.8/site-packages/click/core.py", line 782, in main
#38 7.380     rv = self.invoke(ctx)
#38 7.380   File "/opt/conda/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
#38 7.380     return _process_result(sub_ctx.command.invoke(sub_ctx))
#38 7.380   File "/opt/conda/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
#38 7.380     return ctx.invoke(self.callback, **ctx.params)
#38 7.380   File "/opt/conda/lib/python3.8/site-packages/click/core.py", line 610, in invoke
#38 7.380     return callback(*args, **kwargs)
#38 7.380   File "/home/research/.local/lib/python3.8/site-packages/mim/commands/install.py", line 101, in cli
#38 7.380     install(
#38 7.380   File "/home/research/.local/lib/python3.8/site-packages/mim/commands/install.py", line 205, in install
#38 7.380     install_from_github(target_pkg, target_version, find_url, timeout,
#38 7.380   File "/home/research/.local/lib/python3.8/site-packages/mim/commands/install.py", line 536, in install_from_github
#38 7.380     install_from_repo(
#38 7.380   File "/home/research/.local/lib/python3.8/site-packages/mim/commands/install.py", line 493, in install_from_repo
#38 7.380     call_command(install_cmd)
#38 7.380   File "/home/research/.local/lib/python3.8/site-packages/mim/utils/utils.py", line 420, in call_command
#38 7.380     raise highlighted_error(e)  # type: ignore
#38 7.380   File "/home/research/.local/lib/python3.8/site-packages/mim/utils/utils.py", line 392, in highlighted_error
#38 7.380     return click.style(msg, fg='red', bold=True)  # type: ignore
#38 7.380   File "/opt/conda/lib/python3.8/site-packages/click/termui.py", line 519, in style
#38 7.380     return "".join(bits)
#38 7.380 TypeError: sequence item 2: expected str instance, CalledProcessError found
#38 ERROR: executor failed running [/bin/sh -c mim install mmaction2==0.21.0]: exit code: 1
```

With pip==22.0.4 there is no error but the following message is being printed:
```
DEPRECATION: In-tree builds are now the default. pip 22.1 will enforce this behaviour change. A possible replacement is to remove the --use-feature=in-tree-build flag.
```

More details at https://pip.pypa.io/en/stable/news/#id82

## Modification
Do not use `--use-feature=in-tree-build` if the pip version is >= 22.1.

## BC-breaking (Optional)
-

## Use cases (Optional)
-

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
