### PR TITLE
[Fix]:  fix mim command crashes problem if requirements version conflict

### DIFF
--- a/mim/__init__.py
+++ b/mim/__init__.py
@@ -2,18 +2,18 @@
 
 # flake8: noqa
 
-####### Fix the mim command crashes due to requirements version conflict. ######
+###### Fix mim command crashes problem if requirements version conflict. #######
 # `pkg_resources` checks for a `__requires__` attribute in the `__main__` module
-# when initializing the default working set, and uses this to ensure a suitable
-# version of each affected distribution is activated.
+# when initializing the default working set, and resolves its dependency to
+# ensure a suitable version of each affected distribution is activated.
 #
 # The entry point scripts create by `setuptools` use the `__requires__` feature
 # for compatibility with `easy_install` but may cause mim crash when version
 # conflict exists.
 #
-# Hence, we here remove the `__requires__` declare in mim entry point script before
-# importing pkg_resources to handle this situation. This workaround works fine so
-# far, but not sure if it would cause other unknown problems or not.
+# To handle this situation, we set the `__requires__` declared in mim entry point
+# script from 'openmim' to '' before importing pkg_resources. This workaround works
+# fine so far, but not sure if it would cause other unknown problems or not.
 #
 # Related Links:
 # - https://github.com/open-mmlab/mim/issues/143

--- a/mim/__init__.py
+++ b/mim/__init__.py
@@ -1,4 +1,30 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+
+# flake8: noqa
+
+####### Fix the mim command crashes due to requirements version conflict. ######
+# `pkg_resources` checks for a `__requires__` attribute in the `__main__` module
+# when initializing the default working set, and uses this to ensure a suitable
+# version of each affected distribution is activated.
+#
+# The entry point scripts create by `setuptools` use the `__requires__` feature
+# for compatibility with `easy_install` but may cause mim crash when version
+# conflict exists.
+#
+# Hence, we here remove the `__requires__` declare in mim entry point script before
+# importing pkg_resources to handle this situation. This workaround works fine so
+# far, but not sure if it would cause other unknown problems or not.
+#
+# Related Links:
+# - https://github.com/open-mmlab/mim/issues/143
+# - https://setuptools.pypa.io/en/latest/pkg_resources.html?highlight=__requires__
+# - https://github.com/pypa/setuptools/issues/2198
+
+import sys
+
+sys.modules['__main__'].__requires__ = ''  # type: ignore
+################################# The end! #####################################
+
 from .commands import (
     download,
     get_model_info,


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation
Fixes #143 that mim could be crash if exist version conflict.
For reproduce mim crash:
```bash
> pip install markdown==3.3.7
> pip install importlib-metadata==4.2
> mim list
```


## Modification
- `mim/__init__.py`: set `__requires__` in `__main__` module from 'openmim' to '' avoid requirement resolve check.

## BC-breaking (Optional)

Does the modification introduce changes that break the back-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
