### PR TITLE
doc(customization.md): fix wrong .mimrc example

### DIFF
--- a/docs/en/customization.md
+++ b/docs/en/customization.md
@@ -7,13 +7,13 @@ You can customize MIM using the `~/.mimrc` file, which should be placed in your 
 You can customize the default values of MIM commands with `~/.mimrc`:
 
 ```ini
-[option.train]
+[options.train]
 gpus = 8
 gpus_per_node = 8
 cpus_per_task = 4
 launcher = 'slurm'
 
-[option.install]
+[options.install]
 is_yes = True
 ```
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation
The .mimrc example in customization.md incorrectly uses `[option.xxx]` instead of `[options.xxx]`.

## Modification
- docs/en/customization.md 

## BC-breaking (Optional)

Does the modification introduce changes that break the back-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
