### PR TITLE
[Feat] prompt the built version of mmcv-full

### DIFF
--- a/mim/commands/install.py
+++ b/mim/commands/install.py
@@ -16,6 +16,7 @@ from mim.utils import (
     PKG2PROJECT,
     WHEEL_URL,
     echo_warning,
+    get_all_wheel_version,
     get_torch_cuda_version,
 )
 
@@ -95,7 +96,16 @@ def install(
     importlib.reload(pip._vendor.pkg_resources)
 
     # add mmcv-full find links by default
-    install_args += ['-f', get_mmcv_full_find_link()]
+    mmcv_full_find_link = get_mmcv_full_find_link()
+    install_args += ['-f', mmcv_full_find_link]
+
+    try:
+        # Get and prompt the built version of mmcv-full.
+        all_built_versions = get_all_wheel_version(mmcv_full_find_link)
+        click.echo('The mmcv-full built package version that satisfies the '
+                   f'current environment: {all_built_versions}.')
+    except:  # noqa: E722
+        pass
 
     index_url_opt_names = ['-i', '--index-url', '--pypi-url']
     if any([opt_name in install_args for opt_name in index_url_opt_names]):

--- a/mim/utils/__init__.py
+++ b/mim/utils/__init__.py
@@ -22,6 +22,7 @@ from .utils import (
     ensure_installation,
     exit_with_error,
     extract_tar,
+    get_all_wheel_version,
     get_config,
     get_content_from_url,
     get_github_url,
@@ -88,4 +89,5 @@ __all__ = [
     'parse_home_page',
     'ensure_installation',
     'rich_progress_bar',
+    'get_all_wheel_version',
 ]

--- a/mim/utils/utils.py
+++ b/mim/utils/utils.py
@@ -554,3 +554,32 @@ def module_full_name(abbr: str) -> str:
     elif abbr in names or is_installed(abbr):
         return abbr
     return ''
+
+
+def get_all_wheel_version(index_page_url: str):
+    """Get all wheel version from the given index page url.
+
+    Args:
+        index_page_url (str): The index page url.
+
+    Returns:
+        list: A list of all version of wheel in this page.
+    """
+    response = get_content_from_url(index_page_url, timeout=5)
+    anchors = re.findall(r'<a href="(.*?)">', response.text)
+
+    wheel_file_re = re.compile(
+        r"""^(?P<namever>(?P<name>.+?)-(?P<ver>.*?))
+        ((-(?P<build>\d[^-]*?))?-(?P<pyver>.+?)-(?P<abi>.+?)-(?P<plat>.+?)
+        \.whl|\.dist-info)$""",
+        re.VERBOSE,
+    )
+
+    all_versions = set()
+    for anchor in anchors:
+        wheel_info = wheel_file_re.match(anchor.split('/')[-1])
+        if wheel_info:
+            # TODO: check valid tags (pyversions, abis, plat)
+            all_versions.add(wheel_info.group('ver').replace('_', '-'))
+
+    return sorted(all_versions, key=parse_version)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation
Get and prompt the built version of mmcv-full that satisfies the current environment. close #149 

## Modification
- commands/install.py
- utlis/utils.py
- utils/\_\_init\_\_.py

## BC-breaking (Optional)

Does the modification introduce changes that break the back-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)
<img width="1274" alt="image" src="https://user-images.githubusercontent.com/32220263/177466925-ab99d5a7-3479-4640-8649-e59fcb8d6288.png">


## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
