### PR TITLE
[Fix] fix mim --version crash in click>=8.x

### DIFF
--- a/mim/cli.py
+++ b/mim/cli.py
@@ -6,6 +6,8 @@ from configparser import ConfigParser
 
 import click
 
+from mim.version import __version__
+
 plugin_folder = os.path.join(os.path.dirname(__file__), 'commands')
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
@@ -81,7 +83,7 @@ class MIM(click.MultiCommand):
     expose_value=False,
     help='Read option defaults from the .mimrc file',
     show_default=True)
-@click.version_option()
+@click.version_option(version=__version__)
 def cli():
     """OpenMMLab Command Line Interface.
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,11 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from click.testing import CliRunner
+
+from mim.cli import cli as mim_cli
+
+
+def test_version():
+    # test `mim --version` command
+    runner = CliRunner()
+    result = runner.invoke(mim_cli, ['--version'])
+    assert result.exit_code == 0


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation
The `mim --version` command crash in click>=8.x, fix it by pass the \_\_version\_\_ to `version_option`.

## Modification
- mim/cli.py
- tests/test_version.py

## BC-breaking (Optional)

Does the modification introduce changes that break the back-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
