### PR TITLE
[Fix] Fix the punctuation display problem and the path separator problem on Windows

### DIFF
--- a/mim/click/customcommand.py
+++ b/mim/click/customcommand.py
@@ -107,7 +107,7 @@ class CustomCommand(click.Command):
                     files.extend([osp.join(item[0], x) for x in item[2]])
 
                 files = [x for x in files if x.endswith('.py')]
-                files = [x.split(tool_root + '/')[1] for x in files]
+                files = [x.split(tool_root + os.sep)[1] for x in files]
 
                 if len(files):
                     click.echo('=' * 80)

--- a/mim/commands/gridsearch.py
+++ b/mim/commands/gridsearch.py
@@ -68,7 +68,7 @@ from mim.utils import (
     '-j', '--max-jobs', type=int, help='Max parallel number', default=1)
 @click.option(
     '--srun-args', type=str, help='Other srun arguments that might be used')
-@click.option('-y', '--yes', is_flag=True, help='Don’t ask for confirmation.')
+@click.option('-y', '--yes', is_flag=True, help='Don\'t ask for confirmation.')
 @click.option(
     '--search-args', type=str, help='Arguments for hyper parameters search')
 @click.argument('other_args', nargs=-1, type=click.UNPROCESSED)
@@ -186,7 +186,7 @@ def gridsearch(
             used, all arguments should be in a string. Defaults to None.
         search_args (str, optional): Arguments for hyper parameters search, all
             arguments should be in a string. Defaults to None.
-        yes (bool): Don’t ask for confirmation. Default: True.
+        yes (bool): Don\'t ask for confirmation. Default: True.
         other_args (tuple, optional): Other arguments, will be passed to the
             codebase's training script. Defaults to ().
     """

--- a/mim/commands/run.py
+++ b/mim/commands/run.py
@@ -26,7 +26,7 @@ from mim.utils import (
     cls=CustomCommand)
 @click.argument('package', type=str, callback=param2lowercase)
 @click.argument('command', type=str)
-@click.option('-y', '--yes', is_flag=True, help='Don’t ask for confirmation.')
+@click.option('-y', '--yes', is_flag=True, help='Don\'t ask for confirmation.')
 @click.argument('other_args', nargs=-1, type=click.UNPROCESSED)
 def cli(package: str, command: str, yes: bool, other_args: tuple = ()) -> None:
     """Run arbitrary command of a codebase.
@@ -81,7 +81,7 @@ def run(
     Args:
         package (str): The codebase name.
         command (str): The command name.
-        yes (bool): Don’t ask for confirmation. Default: True.
+        yes (bool): Don\'t ask for confirmation. Default: True.
         other_args (tuple, optional): Other arguments, will be passed to the
             codebase's script. Defaults to ().
     """

--- a/mim/commands/test.py
+++ b/mim/commands/test.py
@@ -64,7 +64,7 @@ from mim.utils import (
     help='The partition to use (only applicable to launcher == "slurm")')
 @click.option(
     '--srun-args', type=str, help='Other srun arguments that might be used')
-@click.option('-y', '--yes', is_flag=True, help='Don’t ask for confirmation.')
+@click.option('-y', '--yes', is_flag=True, help='Don\'t ask for confirmation.')
 @click.argument('other_args', nargs=-1, type=click.UNPROCESSED)
 def cli(package: str,
         config: str,
@@ -160,7 +160,7 @@ def test(
             between 20000 and 30000.
         srun_args (str, optional): Other srun arguments that might be
             used, all arguments should be in a string. Defaults to None.
-        yes (bool): Don’t ask for confirmation. Default: True.
+        yes (bool): Don\'t ask for confirmation. Default: True.
         other_args (tuple, optional): Other arguments, will be passed to the
             codebase's training script. Defaults to ().
     """

--- a/mim/commands/train.py
+++ b/mim/commands/train.py
@@ -59,7 +59,7 @@ from mim.utils import (
     help='The partition to use (only applicable to launcher == "slurm")')
 @click.option(
     '--srun-args', type=str, help='Other srun arguments that might be used')
-@click.option('-y', '--yes', is_flag=True, help='Don’t ask for confirmation.')
+@click.option('-y', '--yes', is_flag=True, help='Don\'t ask for confirmation.')
 @click.argument('other_args', nargs=-1, type=click.UNPROCESSED)
 def cli(package: str,
         config: str,
@@ -147,7 +147,7 @@ def train(
             between 20000 and 30000.
         srun_args (str, optional): Other srun arguments that might be
             used, all arguments should be in a string. Defaults to None.
-        yes (bool): Don’t ask for confirmation. Default: True.
+        yes (bool): Don\'t ask for confirmation. Default: True.
         other_args (tuple, optional): Other arguments, will be passed to the
             codebase's training script. Defaults to ().
     """

--- a/mim/commands/uninstall.py
+++ b/mim/commands/uninstall.py
@@ -23,7 +23,7 @@ from mim.utils import call_command
     '--yes',
     'confirm_yes',
     is_flag=True,
-    help='Don’t ask for confirmation of uninstall deletions.')
+    help='Don\'t ask for confirmation of uninstall deletions.')
 @click.option(
     '-r',
     '--requirement',
@@ -61,7 +61,7 @@ def uninstall(uninstall_args: Union[str, List],
     Args:
         uninstall_args (str or list): A package name or a list of package names
             to uninstalled. You can also put some `pip uninstal` options here.
-        confirm_yes (bool): Don’t ask for confirmation of uninstall deletions.
+        confirm_yes (bool): Don\'t ask for confirmation of uninstall deletions.
             Default: True.
         requirements (tuple): A tuple of requirements files to uninstalled.
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

![1666087934605](https://user-images.githubusercontent.com/27466624/196402557-c0ac1db3-b52c-42a7-8526-f831599d9505.png)
1.Fix the punctuation display problem on Windows, when running the command `mim run mmdet -h`.

![10615f6753552529333432d391461b5](https://user-images.githubusercontent.com/27466624/196402886-b0ee68dd-59fd-4cbe-ab67-328ac63fd0ff.png)
2.Fix the path separator problem on Windows, when running the command `mim run mmdet -h`.

## Modification
Replace all `Don’t` -> `Don\'t` for problem 1.
In `mim/click/customcommand.py`, '/' -> os.sep for problem 2.
