### PR TITLE
[Fix] the path separator problem of `mim run` on Windows

### DIFF
--- a/mim/commands/run.py
+++ b/mim/commands/run.py
@@ -110,8 +110,8 @@ def run(
 
     pkg_root = get_installed_path(package)
     possible_prefixes = [
-        osp.join(pkg_root, '.mim', 'tools/'),
-        osp.join(pkg_root, 'tools/')
+        osp.join(pkg_root, '.mim', f'tools{os.sep}'),
+        osp.join(pkg_root, f'tools{os.sep}')
     ]
     for possible_prefix in possible_prefixes:
         if osp.exists(possible_prefix):
@@ -121,15 +121,15 @@ def run(
     command_domain = ''
     if ':' in command:
         split_command = command.split(':')
-        command_domain = '/'.join(split_command[:-1])
+        command_domain = os.sep.join(split_command[:-1])
         command = split_command[-1]
 
     files = recursively_find(prefix, command + '.py')
 
     if command_domain == '':
-        suffix = f'/{command}.py'
+        suffix = f'{os.sep}{command}.py'
     else:
-        suffix = f'/{command_domain}/{command}.py'
+        suffix = f'{os.sep}{command_domain}{os.sep}{command}.py'
     files = [f for f in files if f.endswith(suffix)]
 
     if len(files) == 0:
@@ -142,11 +142,11 @@ def run(
             echo_warning(f)
 
         # Use the shortest path
-        files.sort(key=lambda x: len(x.split('/')))
+        files.sort(key=lambda x: len(x.split(os.sep)))
         echo_warning(f'We are using the script {files[0]}. ')
         echo_warning('To use other scripts, you need to use these commands: ')
         for f in files[1:]:
-            cmd = f.split(prefix)[1].split('.')[0].replace('/', ':')
+            cmd = f.split(prefix)[1].split('.')[0].replace(os.sep, ':')
             echo_warning(f'Command for {f}: {cmd}')
 
     script = files[0]


### PR DESCRIPTION
## Motivation

`mim run mmdet analyze_logs plot_curve .\yolov5_n-v61_syncbn_fast_8xb16-300e_coco_20220919_090739.l  og.json --keys loss_cls --legend loss_cls`

before:
![image](https://user-images.githubusercontent.com/27466624/204499529-6a0668f7-55d4-4097-a311-1673e9b64e55.png)

after:
![image](https://user-images.githubusercontent.com/27466624/204499842-7ee3f958-e793-4ccf-b805-243a1a2c0164.png)


## Modification

replace all '/' with os.sep in run.py
