### PR TITLE
[Enhancement] Add deactivate SSL certification verity option

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Please refer to [installation.md](docs/en/installation.md) for installation.
   from mim import download
 
   download('mmcls', ['resnet18_8xb16_cifar10'])
+  download('mmcls', ['resnet18_8xb16_cifar10'], dest_dir='.')
   ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -182,7 +182,6 @@ Please refer to [installation.md](docs/en/installation.md) for installation.
   from mim import download
 
   download('mmcls', ['resnet18_8xb16_cifar10'])
-  download('mmcls', ['resnet18_8xb16_cifar10'], check_certificate=False, dest_dir='.')
   ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -174,7 +174,6 @@ Please refer to [installation.md](docs/en/installation.md) for installation.
   ```bash
   > mim download mmcls --config resnet18_8xb16_cifar10
   > mim download mmcls --config resnet18_8xb16_cifar10 --dest .
-  > mim download mmcls --no-check-certificate --config resnet18_8xb16_cifar10 --dest .
   ```
 
 - api

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Please refer to [installation.md](docs/en/installation.md) for installation.
   ```bash
   > mim download mmcls --config resnet18_8xb16_cifar10
   > mim download mmcls --config resnet18_8xb16_cifar10 --dest .
+  > mim download mmcls --no-check-certificate --config resnet18_8xb16_cifar10 --dest .
   ```
 
 - api
@@ -182,7 +183,7 @@ Please refer to [installation.md](docs/en/installation.md) for installation.
   from mim import download
 
   download('mmcls', ['resnet18_8xb16_cifar10'])
-  download('mmcls', ['resnet18_8xb16_cifar10'], dest_dir='.')
+  download('mmcls', ['resnet18_8xb16_cifar10'], check_certificate=False, dest_dir='.')
   ```
 
 </details>

--- a/mim/commands/download.py
+++ b/mim/commands/download.py
@@ -123,7 +123,7 @@ def download(package: str,
             else:
                 # TODO: check checkpoint hash when all the models are ready.
                 download_from_file(checkpoint_url, checkpoint_path,
-                                   check_certificate)
+                                   check_certificate=check_certificate)
 
                 echo_success(
                     f'Successfully downloaded {filename} to {dest_root}')

--- a/mim/commands/download.py
+++ b/mim/commands/download.py
@@ -45,7 +45,7 @@ from mim.utils import (
     '--dest', 'dest_root', type=str, help='Destination of saving checkpoints.')
 def cli(package: str,
         configs: List[str],
-        check_certificate: bool,
+        check_certificate: bool = True,
         dest_root: Optional[str] = None) -> None:
     """Download checkpoints from url and parse configs from package.
 

--- a/mim/commands/download.py
+++ b/mim/commands/download.py
@@ -122,8 +122,10 @@ def download(package: str,
                 echo_success(f'{filename} exists in {dest_root}')
             else:
                 # TODO: check checkpoint hash when all the models are ready.
-                download_from_file(checkpoint_url, checkpoint_path,
-                                   check_certificate=check_certificate)
+                download_from_file(
+                    checkpoint_url,
+                    checkpoint_path,
+                    check_certificate=check_certificate)
 
                 echo_success(
                     f'Successfully downloaded {filename} to {dest_root}')

--- a/mim/commands/download.py
+++ b/mim/commands/download.py
@@ -36,9 +36,16 @@ from mim.utils import (
     required=True,
     help='Config ids to download, such as resnet18_8xb16_cifar10')
 @click.option(
+    '--no-check-certificate',
+    'check_certificate',
+    is_flag=True,
+    default=True,
+    help='Ignore ssl certificate check')
+@click.option(
     '--dest', 'dest_root', type=str, help='Destination of saving checkpoints.')
 def cli(package: str,
         configs: List[str],
+        check_certificate: bool,
         dest_root: Optional[str] = None) -> None:
     """Download checkpoints from url and parse configs from package.
 
@@ -47,20 +54,23 @@ def cli(package: str,
         > mim download mmcls --config resnet18_8xb16_cifar10
         > mim download mmcls --config resnet18_8xb16_cifar10 --dest .
     """
-    download(package, configs, dest_root)
+    download(package, configs, check_certificate, dest_root)
 
 
 def download(package: str,
              configs: List[str],
+             check_certificate: bool = True,
              dest_root: Optional[str] = None) -> List[str]:
     """Download checkpoints from url and parse configs from package.
 
     Args:
         package (str): Name of package.
         configs (List[str]): List of config ids.
+        check_certificate (bool): Whether to check the ssl certificate
         dest_root (Optional[str]): Destination directory to save checkpoint and
             config. Default: None.
     """
+    print(check_certificate)
     if dest_root is None:
         dest_root = DEFAULT_CACHE_DIR
 
@@ -112,7 +122,8 @@ def download(package: str,
                 echo_success(f'{filename} exists in {dest_root}')
             else:
                 # TODO: check checkpoint hash when all the models are ready.
-                download_from_file(checkpoint_url, checkpoint_path)
+                download_from_file(checkpoint_url, checkpoint_path,
+                                   check_certificate)
 
                 echo_success(
                     f'Successfully downloaded {filename} to {dest_root}')

--- a/mim/commands/download.py
+++ b/mim/commands/download.py
@@ -70,7 +70,6 @@ def download(package: str,
         dest_root (Optional[str]): Destination directory to save checkpoint and
             config. Default: None.
     """
-    print(check_certificate)
     if dest_root is None:
         dest_root = DEFAULT_CACHE_DIR
 

--- a/mim/commands/download.py
+++ b/mim/commands/download.py
@@ -36,7 +36,7 @@ from mim.utils import (
     required=True,
     help='Config ids to download, such as resnet18_8xb16_cifar10')
 @click.option(
-    '--no-check-certificate',
+    '--ignore-ssl',
     'check_certificate',
     is_flag=True,
     default=True,
@@ -45,8 +45,8 @@ from mim.utils import (
     '--dest', 'dest_root', type=str, help='Destination of saving checkpoints.')
 def cli(package: str,
         configs: List[str],
-        check_certificate: bool = True,
-        dest_root: Optional[str] = None) -> None:
+        dest_root: Optional[str] = None,
+        check_certificate: bool = True) -> None:
     """Download checkpoints from url and parse configs from package.
 
     \b
@@ -54,22 +54,22 @@ def cli(package: str,
         > mim download mmcls --config resnet18_8xb16_cifar10
         > mim download mmcls --config resnet18_8xb16_cifar10 --dest .
     """
-    download(package, configs, check_certificate, dest_root)
+    download(package, configs, dest_root, check_certificate)
 
 
 def download(package: str,
              configs: List[str],
-             check_certificate: bool = True,
-             dest_root: Optional[str] = None) -> List[str]:
+             dest_root: Optional[str] = None,
+             check_certificate: bool = True) -> List[str]:
     """Download checkpoints from url and parse configs from package.
 
     Args:
         package (str): Name of package.
         configs (List[str]): List of config ids.
-        check_certificate (bool): Whether to check the ssl certificate.
-            Default: True.
         dest_root (Optional[str]): Destination directory to save checkpoint and
             config. Default: None.
+        check_certificate (bool): Whether to check the ssl certificate.
+            Default: True.
     """
     if dest_root is None:
         dest_root = DEFAULT_CACHE_DIR

--- a/mim/commands/download.py
+++ b/mim/commands/download.py
@@ -66,7 +66,8 @@ def download(package: str,
     Args:
         package (str): Name of package.
         configs (List[str]): List of config ids.
-        check_certificate (bool): Whether to check the ssl certificate
+        check_certificate (bool): Whether to check the ssl certificate.
+            Default: True.
         dest_root (Optional[str]): Destination directory to save checkpoint and
             config. Default: None.
     """

--- a/mim/utils/utils.py
+++ b/mim/utils/utils.py
@@ -141,6 +141,8 @@ def get_content_from_url(url: str,
     Args:
         url (str): Url for getting content.
         timeout (int): Set the socket timeout. Default: 15.
+        check_certificate (bool): Whether to check the ssl certificate.
+            Default: True.
     """
     try:
         response = requests.get(
@@ -166,7 +168,8 @@ def download_from_file(url: str,
     Args:
         url (str): URL of the object to download.
         dest_path (str): Path where object will be saved.
-        check_certificate (bool): Whether to check the ssl certificate
+        check_certificate (bool): Whether to check the ssl certificate.
+            Default: True.
         hash_prefix (string, optional): If not None, the SHA256 downloaded
             file should start with `hash_prefix`. Default: None.
     """

--- a/mim/utils/utils.py
+++ b/mim/utils/utils.py
@@ -134,7 +134,8 @@ def get_github_url(package: str) -> str:
 
 def get_content_from_url(url: str,
                          timeout: int = 15,
-                         stream: bool = False) -> Response:
+                         stream: bool = False,
+                         check_certificate: bool = True) -> Response:
     """Get content from url.
 
     Args:
@@ -142,7 +143,8 @@ def get_content_from_url(url: str,
         timeout (int): Set the socket timeout. Default: 15.
     """
     try:
-        response = requests.get(url, timeout=timeout, stream=stream)
+        response = requests.get(
+            url, timeout=timeout, stream=stream, verify=check_certificate)
     except InvalidURL as err:
         raise highlighted_error(err)  # type: ignore
     except Timeout as err:
@@ -157,19 +159,22 @@ def get_content_from_url(url: str,
 @typing.no_type_check
 def download_from_file(url: str,
                        dest_path: str,
+                       check_certificate: bool,
                        hash_prefix: Optional[str] = None) -> None:
     """Download object at the given URL to a local path.
 
     Args:
         url (str): URL of the object to download.
         dest_path (str): Path where object will be saved.
+        check_certificate (bool): Whether to check the ssl certificate
         hash_prefix (string, optional): If not None, the SHA256 downloaded
             file should start with `hash_prefix`. Default: None.
     """
     if hash_prefix is not None:
         sha256 = hashlib.sha256()
 
-    response = get_content_from_url(url, stream=True)
+    response = get_content_from_url(
+        url, stream=True, check_certificate=check_certificate)
     size = int(response.headers.get('content-length'))
     with open(dest_path, 'wb') as fw:
         content_iter = response.iter_content(chunk_size=1024)

--- a/mim/utils/utils.py
+++ b/mim/utils/utils.py
@@ -162,16 +162,16 @@ def get_content_from_url(url: str,
 def download_from_file(url: str,
                        dest_path: str,
                        hash_prefix: Optional[str] = None,
-                       check_certificate: bool) -> None:
+                       check_certificate: bool = True) -> None:
     """Download object at the given URL to a local path.
 
     Args:
         url (str): URL of the object to download.
         dest_path (str): Path where object will be saved.
-        check_certificate (bool): Whether to check the ssl certificate.
-            Default: True.
         hash_prefix (string, optional): If not None, the SHA256 downloaded
             file should start with `hash_prefix`. Default: None.
+        check_certificate (bool): Whether to check the ssl certificate.
+            Default: True.
     """
     if hash_prefix is not None:
         sha256 = hashlib.sha256()

--- a/mim/utils/utils.py
+++ b/mim/utils/utils.py
@@ -161,8 +161,8 @@ def get_content_from_url(url: str,
 @typing.no_type_check
 def download_from_file(url: str,
                        dest_path: str,
-                       check_certificate: bool,
-                       hash_prefix: Optional[str] = None) -> None:
+                       hash_prefix: Optional[str] = None,
+                       check_certificate: bool) -> None:
     """Download object at the given URL to a local path.
 
     Args:


### PR DESCRIPTION
Enables to disable ssl certificate checking

## Motivation

Add the option not to check ssl certificate to allow downloads to be performed in environments where ssl errors occur (for example, on-premises)

## Modification

Some codes have been modified so that the requests module can select whether to check the ssl certificate or not module.

## Use cases 

> mim download mmcls **--no-check-certificate** --config resnet18_8xb16_cifar10 --dest .


