### PR TITLE
[Fix] fix UserWarning of _distutils_hack

### DIFF
--- a/mim/click/compat.py
+++ b/mim/click/compat.py
@@ -1,8 +1,8 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from distutils.version import LooseVersion
 from typing import Callable
 
 import click
+from pip._vendor.packaging import version
 
 
 def autocompletion_to_shell_complete(autocompletion: Callable) -> Callable:
@@ -44,7 +44,7 @@ def argument(*param_decls, **attrs):
     """
     # 'autocompletion' will be removed in Click 8.1 and its new name is
     # 'shell_complete'.
-    if LooseVersion(click.__version__) >= LooseVersion('8.0.0'):
+    if version.parse(click.__version__) >= version.parse('8.0.0'):
         autocompletion = attrs.pop('autocompletion', None)
         if autocompletion is not None:
             attrs['shell_complete'] = autocompletion_to_shell_complete(

--- a/mim/utils/utils.py
+++ b/mim/utils/utils.py
@@ -10,13 +10,13 @@ import subprocess
 import tarfile
 import typing
 from collections import defaultdict
-from distutils.version import LooseVersion
 from email.parser import FeedParser
 from pkg_resources import get_distribution, parse_version
 from typing import Any, List, Optional, Tuple, Union
 
 import click
 import requests
+from pip._vendor.packaging import version
 from requests.exceptions import InvalidURL, RequestException, Timeout
 from requests.models import Response
 
@@ -285,7 +285,7 @@ def get_latest_version(package: str, timeout: int = 15) -> str:
 
 
 def is_version_equal(version1: str, version2: str) -> bool:
-    return LooseVersion(version1) == LooseVersion(version2)
+    return version.parse(version1) == version.parse(version2)
 
 
 @ensure_installation


### PR DESCRIPTION
## Motivation
Fix UserWarning:
```
> mim list
/xxx/lib/python3.8/site-packages/_distutils_hack/__init__.py:30: UserWarning: Setuptools is replacing distutils.
  warnings.warn("Setuptools is replacing distutils.")
Package    Version    Source
---------  ---------  --------
```

## Modification
Use `pip._vendoring.packaging.version` instead of `distutils.version`.

## BC-breaking (Optional)
The `pip._vendoring.packaging.version` works fine since `pip>=10.0.0b1` (2018/3/20)
