### PR TITLE
[Enhance] Support CPU-only train and test in slurm cluster (#189)

### DIFF
--- a/mim/commands/gridsearch.py
+++ b/mim/commands/gridsearch.py
@@ -201,9 +201,8 @@ def gridsearch(
 
     # If launcher == "slurm", must have following args
     if launcher == 'slurm':
-        msg = ('If launcher is slurm, '
-               'gpus-per-node and partition should not be None')
-        flag = (gpus_per_node is not None) and (partition is not None)
+        msg = 'If launcher is slurm, partition should not be None'
+        flag = partition is not None
         if not flag:
             raise AssertionError(highlighted_error(msg))
 
@@ -382,12 +381,19 @@ def gridsearch(
             if not has_job_name:
                 job_name = osp.splitext(osp.basename(config_path))[0]
                 parsed_srun_args.append(f'--job-name={job_name}_train')
-            cmd = [
+            if gpus:
+                cmd = [
                 'srun', '-p', f'{partition}', f'--gres=gpu:{gpus_per_node}',
                 f'--ntasks={gpus}', f'--ntasks-per-node={gpus_per_node}',
                 f'--cpus-per-task={cpus_per_task}', '--kill-on-bad-exit=1'
-            ] + parsed_srun_args + [PYTHON, '-u', train_script, config_path
-                                    ] + common_args
+                ] + parsed_srun_args + [PYTHON, '-u', train_script,
+                                        config_path] + common_args
+            else:
+                cmd = [
+                'srun', '-p', f'{partition}',
+                f'--cpus-per-task={cpus_per_task}', '--kill-on-bad-exit=1'
+                ] + parsed_srun_args + [PYTHON, '-u', train_script,
+                                        config] + common_args
 
         cmds.append(cmd)
 

--- a/mim/commands/test.py
+++ b/mim/commands/test.py
@@ -190,10 +190,8 @@ def test(
 
     # If launcher == "slurm", must have following args
     if launcher == 'slurm':
-        msg = ('If launcher is slurm, '
-               'gpus, gpus-per-node and partition should not be None')
-        flag = (gpus_per_node
-                is not None) and (partition is not None) and (gpus is not None)
+        msg = 'If launcher is slurm, partition should not be None'
+        flag = partition is not None
         assert flag, msg
 
     if not is_installed(package):

--- a/mim/commands/test.py
+++ b/mim/commands/test.py
@@ -270,11 +270,17 @@ def test(
         if not has_job_name:
             job_name = osp.splitext(osp.basename(config))[0]
             parsed_srun_args.append(f'--job-name={job_name}_test')
-        cmd = [
-            'srun', '-p', f'{partition}', f'--gres=gpu:{gpus_per_node}',
-            f'--ntasks={gpus}', f'--ntasks-per-node={gpus_per_node}',
-            f'--cpus-per-task={cpus_per_task}', '--kill-on-bad-exit=1'
-        ]
+        if gpus:
+            cmd = [
+                'srun', '-p', f'{partition}', f'--gres=gpu:{gpus_per_node}',
+                f'--ntasks={gpus}', f'--ntasks-per-node={gpus_per_node}',
+                f'--cpus-per-task={cpus_per_task}', '--kill-on-bad-exit=1'
+            ]
+        else:
+            cmd = [
+                'srun', '-p', f'{partition}',
+                f'--cpus-per-task={cpus_per_task}', '--kill-on-bad-exit=1'
+            ]
         cmd += parsed_srun_args
         cmd += [PYTHON, '-u', test_script, config]
         if checkpoint:

--- a/mim/commands/train.py
+++ b/mim/commands/train.py
@@ -248,12 +248,19 @@ def train(
         if not has_job_name:
             job_name = osp.splitext(osp.basename(config))[0]
             parsed_srun_args.append(f'--job-name={job_name}_train')
-        cmd = [
-            'srun', '-p', f'{partition}', f'--gres=gpu:{gpus_per_node}',
-            f'--ntasks={gpus}', f'--ntasks-per-node={gpus_per_node}',
-            f'--cpus-per-task={cpus_per_task}', '--kill-on-bad-exit=1'
-        ] + parsed_srun_args + [PYTHON, '-u', train_script, config
-                                ] + common_args
+        if gpus:
+            cmd = [
+                'srun', '-p', f'{partition}', f'--gres=gpu:{gpus_per_node}',
+                f'--ntasks={gpus}', f'--ntasks-per-node={gpus_per_node}',
+                f'--cpus-per-task={cpus_per_task}', '--kill-on-bad-exit=1'
+                ] + parsed_srun_args + [PYTHON, '-u', train_script, config
+                                          ] + common_args
+        else:
+            cmd = [
+                'srun', '-p', f'{partition}',
+                f'--cpus-per-task={cpus_per_task}', '--kill-on-bad-exit=1'
+                ] + parsed_srun_args + [PYTHON, '-u', train_script, config
+                                          ] + common_args
 
     cmd_text = ' '.join(cmd)
     click.echo(f'Training command is {cmd_text}. ')

--- a/mim/commands/train.py
+++ b/mim/commands/train.py
@@ -162,9 +162,8 @@ def train(
 
     # If launcher == "slurm", must have following args
     if launcher == 'slurm':
-        msg = ('If launcher is slurm, '
-               'gpus-per-node and partition should not be None')
-        flag = (gpus_per_node is not None) and (partition is not None)
+        msg = 'If launcher is slurm, partition should not be None'
+        flag = partition is not None
         assert flag, msg
 
     if port is None:


### PR DESCRIPTION
## Motivation

Support CPU-only train and test in slurm cluster. (#189) 

## Modification

Modify slurm check conditions to "flag = partition is not None"

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
