### PR TITLE
[Fix] decode URL encoded string in config path

### DIFF
--- a/mim/commands/download.py
+++ b/mim/commands/download.py
@@ -2,6 +2,7 @@
 import os
 import os.path as osp
 from typing import List, Optional
+from urllib.parse import unquote
 
 import click
 
@@ -132,6 +133,7 @@ def download(package: str,
 
         config_paths = model_info[config]['config']
         for config_path in config_paths.split(','):
+            config_path = unquote(config_path)
             installed_path = get_installed_path(package)
             # configs will be put in package/.mim in PR #68
             possible_config_paths = [


### PR DESCRIPTION

## Motivation

Some packages has config paths which is url encoded (e.g. %2B for +) https://github.com/open-mmlab/mmdetection/blob/db85fd12afce2fe89d1c7b870874c02a90018a16/configs/gn%2Bws/metafile.yml#L17

Currently downloading those models trrigers "is not found" error because mim does not support url encoded path.


## Modification


While I am not sure if this should be fixed in mim or in metafile.yml in the package, I firstly attempt to fix in mim package.

## BC-breaking (Optional)

-

## Use cases (Optional)

-

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
