### PR TITLE
[Enhance] Add support for sequence input in ``--search-args`` option

### DIFF
--- a/mim/utils/utils.py
+++ b/mim/utils/utils.py
@@ -12,7 +12,7 @@ import typing
 from collections import defaultdict
 from email.parser import FeedParser
 from pkg_resources import get_distribution, parse_version
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, List, Optional, Sequence, Tuple, Union
 
 import click
 import requests
@@ -509,8 +509,11 @@ def get_config(cfg, name):
     name = name.split('.')
     suffix = ''
     for item in name:
-        assert item in cfg, f'attribute {item} not cfg{suffix}'
-        cfg = cfg[item]
+        if isinstance(cfg, Sequence) and not isinstance(cfg, str):
+            cfg = cfg[int(item)]
+        else:
+            assert item in cfg, f'attribute {item} not cfg{suffix}'
+            cfg = cfg[item]
         suffix += f'.{item}'
     return cfg
 
@@ -524,8 +527,11 @@ def set_config(cfg, name, value):
     name = name.split('.')
     suffix = ''
     for item in name[:-1]:
-        assert item in cfg, f'attribute {item} not cfg{suffix}'
-        cfg = cfg[item]
+        if isinstance(cfg, Sequence) and not isinstance(cfg, str):
+            cfg = cfg[int(item)]
+        else:
+            assert item in cfg, f'attribute {item} not cfg{suffix}'
+            cfg = cfg[item]
         suffix += f'.{item}'
 
     assert name[-1] in cfg, f'attribute {item} not cfg{suffix}'

--- a/tests/data/lenet5_mnist_2.0.py
+++ b/tests/data/lenet5_mnist_2.0.py
@@ -12,7 +12,11 @@ model = dict(
 dataset_type = 'MNIST'
 data_preprocessor = dict(mean=[33.46], std=[78.87])
 
-pipeline = [dict(type='Resize', scale=32), dict(type='PackClsInputs')]
+pipeline = [
+    dict(type='Resize', scale=32),
+    dict(type='Pad', size=(32, 32)),
+    dict(type='PackClsInputs')
+]
 
 common_data_cfg = dict(
     type=dataset_type, data_prefix='data/mnist', pipeline=pipeline)

--- a/tests/test_gridsearch.py
+++ b/tests/test_gridsearch.py
@@ -60,7 +60,7 @@ def test_gridsearch(gpus, tmp_path):
     args5 = [
         'mmcls', 'tests/data/lenet5_mnist_2.0.py', f'--gpus={gpus}',
         f'--work-dir={tmp_path}', '--search-args',
-        '--train_dataloader.dataset.pipeline.0.scale 8 16 32'
+        '--train_dataloader.dataset.pipeline.0.scale 16 32'
     ]
 
     result = runner.invoke(gridsearch, args1)

--- a/tests/test_gridsearch.py
+++ b/tests/test_gridsearch.py
@@ -57,6 +57,12 @@ def test_gridsearch(gpus, tmp_path):
         f'--work-dir={tmp_path}', '--search-args'
     ]
 
+    args5 = [
+        'mmcls', 'tests/data/lenet5_mnist_2.0.py', f'--gpus={gpus}',
+        f'--work-dir={tmp_path}', '--search-args',
+        '--train_dataloader.dataset.pipeline.0.scale 8 16 32'
+    ]
+
     result = runner.invoke(gridsearch, args1)
     assert result.exit_code == 0
 
@@ -68,6 +74,9 @@ def test_gridsearch(gpus, tmp_path):
 
     result = runner.invoke(gridsearch, args4)
     assert result.exit_code != 0
+
+    result = runner.invoke(gridsearch, args5)
+    assert result.exit_code == 0
 
 
 def teardown_module():


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

```bash
mim gridsearch mmcls $CONFIG --work-dir $WORK_DIR --gpus $GPUS \
    --search-args --train_dataloader.dataset.pipeline.0.key val1 val2 ...
```

```bash
Traceback (most recent call last):
  File "/opt/conda/lib/python3.7/site-packages/mim/commands/gridsearch.py", line 288, in gridsearch
    arg_value = get_config(cfg, arg)
  File "/opt/conda/lib/python3.7/site-packages/mim/utils/utils.py", line 515, in get_config
    assert item in cfg, f'attribute {item} not cfg{suffix}'
AssertionError: attribute 1 not cfg.train_dataloader.dataset.pipeline

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/conda/bin/mim", line 8, in <module>
    sys.exit(cli())
  File "/opt/conda/lib/python3.7/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/opt/conda/lib/python3.7/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/opt/conda/lib/python3.7/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/conda/lib/python3.7/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/conda/lib/python3.7/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/opt/conda/lib/python3.7/site-packages/mim/commands/gridsearch.py", line 146, in cli
    other_args=other_args)
  File "/opt/conda/lib/python3.7/site-packages/mim/commands/gridsearch.py", line 298, in gridsearch
    raise AssertionError(highlighted_error(msg))
AssertionError: Arg train_dataloader.dataset.pipeline.0.key not in the config file. 
```

## Modification

I added logic to handle the case when `cfg` is instance of `Sequence` in `get_config` and `set_config` functions

## BC-breaking (Optional)

Does the modification introduce changes that break the back-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
