### PR TITLE
[Fix] Fix AssertionError when importing pip before setuptools

### DIFF
--- a/mim/__init__.py
+++ b/mim/__init__.py
@@ -1,4 +1,18 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+
+# NOTE: Since we could got AssertionError when importing pip before
+# setuptools. A workaround is to import setuptools first and filter
+# warnings that cased by setuptools replacing distutils.
+# Related issues:
+# - https://github.com/pypa/setuptools/issues/3621
+# - https://github.com/open-mmlab/mmclassification/issues/1343
+try:
+    import setuptools  # noqa: F401
+    import warnings
+    warnings.filterwarnings('ignore', 'Setuptools is replacing distutils')
+except ImportError:
+    pass
+
 from .commands import (
     download,
     get_model_info,

--- a/mim/__init__.py
+++ b/mim/__init__.py
@@ -1,8 +1,8 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 
-# NOTE: Since we could got AssertionError when importing pip before
+# NOTE: We could got AssertionError when importing pip before
 # setuptools. A workaround is to import setuptools first and filter
-# warnings that cased by setuptools replacing distutils.
+# warnings that are caused by setuptools replacing distutils.
 # Related issues:
 # - https://github.com/pypa/setuptools/issues/3621
 # - https://github.com/open-mmlab/mmclassification/issues/1343


### PR DESCRIPTION
## Motivation
We could get AssertionError when importing pip before setuptools. A workaround is to import setuptools first and filter warnings that are caused by setuptools replacing distutils.

Fix https://github.com/open-mmlab/mmclassification/issues/1343

Related issues:
- https://github.com/pypa/setuptools/issues/3621

## Modification
- `mim/__init__.py`