### PR TITLE
[Fix] Add missing repos in `get_official_package`

### DIFF
--- a/mim/click/autocompletion.py
+++ b/mim/click/autocompletion.py
@@ -30,4 +30,8 @@ def get_official_package(ctx=None, args=None, incomplete=None):
         'mmedit',
         'mmocr',
         'mmgen',
+        'mmselfsup'
+        'mmrotate',
+        'mmflow',
+        'mmyolo',
     ]


### PR DESCRIPTION
## Motivation

Add missing repos in `get_official_package` to be consistent with 
https://github.com/open-mmlab/mim/blob/2a6adf55cb1382bd2aa5d99a69ab2fa513573083/mim/utils/default.py#L16-L32
